### PR TITLE
Assembler: Tokenize instruction/data lines better

### DIFF
--- a/GekkoAssembler.Common/Assembler.cs
+++ b/GekkoAssembler.Common/Assembler.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text.RegularExpressions;
 using GekkoAssembler.DataSections;
 using GekkoAssembler.GekkoInstructions;
 using GekkoAssembler.IntermediateRepresentation;
@@ -99,110 +100,111 @@ namespace GekkoAssembler
 
         private IIRUnit ParseSpecialInstruction(string line, ref int instructionPointer, Queue<string> lines)
         {
-            if (line.StartsWith("u8mask "))
-                return ParseUnsigned8Mask(line, instructionPointer, lines);
-            if (line.StartsWith("u16mask "))
-                return ParseUnsigned16Mask(line, instructionPointer, lines);
+            var tokens = TokenizeLine(line);
 
-            if (line.StartsWith("u8equal "))
-                return ParseUnsigned8Equal(line, instructionPointer, lines);
-            if (line.StartsWith("u16equal "))
-                return ParseUnsigned16Equal(line, instructionPointer, lines);
-            if (line.StartsWith("u32equal "))
-                return ParseUnsigned32Equal(line, instructionPointer, lines);
-            if (line.StartsWith("s8equal "))
-                return ParseSigned8Equal(line, instructionPointer, lines);
-            if (line.StartsWith("s16equal "))
-                return ParseSigned16Equal(line, instructionPointer, lines);
-            if (line.StartsWith("s32equal "))
-                return ParseSigned32Equal(line, instructionPointer, lines);
-            if (line.StartsWith("f32equal "))
-                return ParseFloat32Equal(line, instructionPointer, lines);
+            if (tokens[0] == "u8mask")
+                return ParseUnsigned8Mask(tokens, instructionPointer, lines);
+            if (tokens[0] == "u16mask")
+                return ParseUnsigned16Mask(tokens, instructionPointer, lines);
 
-            if (line.StartsWith("u8unequal "))
-                return ParseUnsigned8Unequal(line, instructionPointer, lines);
-            if (line.StartsWith("u16unequal "))
-                return ParseUnsigned16Unequal(line, instructionPointer, lines);
-            if (line.StartsWith("u32unequal "))
-                return ParseUnsigned32Unequal(line, instructionPointer, lines);
-            if (line.StartsWith("s8unequal "))
-                return ParseSigned8Unequal(line, instructionPointer, lines);
-            if (line.StartsWith("s16unequal "))
-                return ParseSigned16Unequal(line, instructionPointer, lines);
-            if (line.StartsWith("s32unequal "))
-                return ParseSigned32Unequal(line, instructionPointer, lines);
-            if (line.StartsWith("f32unequal "))
-                return ParseFloat32Unequal(line, instructionPointer, lines);
+            if (tokens[0] == "u8equal")
+                return ParseUnsigned8Equal(tokens, instructionPointer, lines);
+            if (tokens[0] == "u16equal")
+                return ParseUnsigned16Equal(tokens, instructionPointer, lines);
+            if (tokens[0] == "u32equal")
+                return ParseUnsigned32Equal(tokens, instructionPointer, lines);
+            if (tokens[0] == "s8equal")
+                return ParseSigned8Equal(tokens, instructionPointer, lines);
+            if (tokens[0] == "s16equal")
+                return ParseSigned16Equal(tokens, instructionPointer, lines);
+            if (tokens[0] == "s32equal")
+                return ParseSigned32Equal(tokens, instructionPointer, lines);
+            if (tokens[0] == "f32equal")
+                return ParseFloat32Equal(tokens, instructionPointer, lines);
 
-            if (line.StartsWith("u8lessthan "))
-                return ParseUnsigned8LessThan(line, instructionPointer, lines);
-            if (line.StartsWith("u16lessthan "))
-                return ParseUnsigned16LessThan(line, instructionPointer, lines);
-            if (line.StartsWith("u32lessthan "))
-                return ParseUnsigned32LessThan(line, instructionPointer, lines);
-            if (line.StartsWith("s8lessthan "))
-                return ParseSigned8LessThan(line, instructionPointer, lines);
-            if (line.StartsWith("s16lessthan "))
-                return ParseSigned16LessThan(line, instructionPointer, lines);
-            if (line.StartsWith("s32lessthan "))
-                return ParseSigned32LessThan(line, instructionPointer, lines);
-            if (line.StartsWith("f32lessthan "))
-                return ParseFloat32LessThan(line, instructionPointer, lines);
+            if (tokens[0] == "u8unequal")
+                return ParseUnsigned8Unequal(tokens, instructionPointer, lines);
+            if (tokens[0] == "u16unequal")
+                return ParseUnsigned16Unequal(tokens, instructionPointer, lines);
+            if (tokens[0] == "u32unequal")
+                return ParseUnsigned32Unequal(tokens, instructionPointer, lines);
+            if (tokens[0] == "s8unequal")
+                return ParseSigned8Unequal(tokens, instructionPointer, lines);
+            if (tokens[0] == "s16unequal")
+                return ParseSigned16Unequal(tokens, instructionPointer, lines);
+            if (tokens[0] == "s32unequal")
+                return ParseSigned32Unequal(tokens, instructionPointer, lines);
+            if (tokens[0] == "f32unequal")
+                return ParseFloat32Unequal(tokens, instructionPointer, lines);
 
-            if (line.StartsWith("u8greaterthan "))
-                return ParseUnsigned8GreaterThan(line, instructionPointer, lines);
-            if (line.StartsWith("u16greaterthan "))
-                return ParseUnsigned16GreaterThan(line, instructionPointer, lines);
-            if (line.StartsWith("u32greaterthan "))
-                return ParseUnsigned32GreaterThan(line, instructionPointer, lines);
-            if (line.StartsWith("s8greaterthan "))
-                return ParseSigned8GreaterThan(line, instructionPointer, lines);
-            if (line.StartsWith("s16greaterthan "))
-                return ParseSigned16GreaterThan(line, instructionPointer, lines);
-            if (line.StartsWith("s32greaterthan "))
-                return ParseSigned32GreaterThan(line, instructionPointer, lines);
-            if (line.StartsWith("f32greaterthan "))
-                return ParseFloat32GreaterThan(line, instructionPointer, lines);
+            if (tokens[0] == "u8lessthan")
+                return ParseUnsigned8LessThan(tokens, instructionPointer, lines);
+            if (tokens[0] == "u16lessthan")
+                return ParseUnsigned16LessThan(tokens, instructionPointer, lines);
+            if (tokens[0] == "u32lessthan")
+                return ParseUnsigned32LessThan(tokens, instructionPointer, lines);
+            if (tokens[0] == "s8lessthan")
+                return ParseSigned8LessThan(tokens, instructionPointer, lines);
+            if (tokens[0] == "s16lessthan")
+                return ParseSigned16LessThan(tokens, instructionPointer, lines);
+            if (tokens[0] == "s32lessthan")
+                return ParseSigned32LessThan(tokens, instructionPointer, lines);
+            if (tokens[0] == "f32lessthan")
+                return ParseFloat32LessThan(tokens, instructionPointer, lines);
 
-            if (line.StartsWith("u8add "))
-                return ParseUnsigned8Add(line, ref instructionPointer);
-            if (line.StartsWith("u16add "))
-                return ParseUnsigned16Add(line, ref instructionPointer);
-            if (line.StartsWith("u32add "))
-                return ParseUnsigned32Add(line, ref instructionPointer);
-            if (line.StartsWith("s8add "))
-                return ParseSigned8Add(line, ref instructionPointer);
-            if (line.StartsWith("s16add "))
-                return ParseSigned16Add(line, ref instructionPointer);
-            if (line.StartsWith("s32add "))
-                return ParseSigned32Add(line, ref instructionPointer);
-            if (line.StartsWith("f32add "))
-                return ParseFloat32Add(line, ref instructionPointer);
+            if (tokens[0] == "u8greaterthan")
+                return ParseUnsigned8GreaterThan(tokens, instructionPointer, lines);
+            if (tokens[0] == "u16greaterthan")
+                return ParseUnsigned16GreaterThan(tokens, instructionPointer, lines);
+            if (tokens[0] == "u32greaterthan")
+                return ParseUnsigned32GreaterThan(tokens, instructionPointer, lines);
+            if (tokens[0] == "s8greaterthan")
+                return ParseSigned8GreaterThan(tokens, instructionPointer, lines);
+            if (tokens[0] == "s16greaterthan")
+                return ParseSigned16GreaterThan(tokens, instructionPointer, lines);
+            if (tokens[0] == "s32greaterthan")
+                return ParseSigned32GreaterThan(tokens, instructionPointer, lines);
+            if (tokens[0] == "f32greaterthan")
+                return ParseFloat32GreaterThan(tokens, instructionPointer, lines);
 
-            if (line.StartsWith("u8bitset "))
-                return ParseUnsigned8BitSet(line, ref instructionPointer);
-            if (line.StartsWith("u16bitset "))
-                return ParseUnsigned16BitSet(line, ref instructionPointer);
-            if (line.StartsWith("u32bitset "))
-                return ParseUnsigned32BitSet(line, ref instructionPointer);
+            if (tokens[0] == "u8add")
+                return ParseUnsigned8Add(tokens, ref instructionPointer);
+            if (tokens[0] == "u16add")
+                return ParseUnsigned16Add(tokens, ref instructionPointer);
+            if (tokens[0] == "u32add")
+                return ParseUnsigned32Add(tokens, ref instructionPointer);
+            if (tokens[0] == "s8add")
+                return ParseSigned8Add(tokens, ref instructionPointer);
+            if (tokens[0] == "s16add")
+                return ParseSigned16Add(tokens, ref instructionPointer);
+            if (tokens[0] == "s32add")
+                return ParseSigned32Add(tokens, ref instructionPointer);
+            if (tokens[0] == "f32add")
+                return ParseFloat32Add(tokens, ref instructionPointer);
 
-            if (line.StartsWith("u8bitunset "))
-                return ParseUnsigned8BitUnset(line, ref instructionPointer);
-            if (line.StartsWith("u16bitunset "))
-                return ParseUnsigned16BitUnset(line, ref instructionPointer);
-            if (line.StartsWith("u32bitunset "))
-                return ParseUnsigned32BitUnset(line, ref instructionPointer);
+            if (tokens[0] == "u8bitset")
+                return ParseUnsigned8BitSet(tokens, ref instructionPointer);
+            if (tokens[0] == "u16bitset")
+                return ParseUnsigned16BitSet(tokens, ref instructionPointer);
+            if (tokens[0] == "u32bitset")
+                return ParseUnsigned32BitSet(tokens, ref instructionPointer);
 
-            if (line.StartsWith("repeat "))
-                return ParseRepeat(line, ref instructionPointer, lines);
+            if (tokens[0] == "u8bitunset")
+                return ParseUnsigned8BitUnset(tokens, ref instructionPointer);
+            if (tokens[0] == "u16bitunset")
+                return ParseUnsigned16BitUnset(tokens, ref instructionPointer);
+            if (tokens[0] == "u32bitunset")
+                return ParseUnsigned32BitUnset(tokens, ref instructionPointer);
 
-            throw new ArgumentException($"The specified special instruction { line } is not supported.");
+            if (tokens[0] == "repeat")
+                return ParseRepeat(tokens, ref instructionPointer, lines);
+
+            throw new ArgumentException($"The specified special instruction { tokens[0] } is not supported.");
         }
 
-        private IIRUnit ParseRepeat(string line, ref int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseRepeat(string[] tokens, ref int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "repeat");
-            var value = ParseIntegerLiteral(parameters[0]);
+            var value = ParseIntegerLiteral(tokens[1]);
             var units = new List<IIRUnit>();
             for (var i = 0; i < value - 1; ++i)
             {
@@ -218,18 +220,16 @@ namespace GekkoAssembler
 
         #region Mask
 
-        private IIRUnit ParseUnsigned8Mask(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseUnsigned8Mask(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "u8mask");
-            var value = (byte)ParseIntegerLiteral(parameters[0]);
+            var value = (byte)ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRUnsigned8Mask(instructionPointer, value, block);
         }
 
-        private IIRUnit ParseUnsigned16Mask(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseUnsigned16Mask(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "u16mask");
-            var value = (ushort)ParseIntegerLiteral(parameters[0]);
+            var value = (ushort)ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRUnsigned16Mask(instructionPointer, value, block);
         }
@@ -238,28 +238,25 @@ namespace GekkoAssembler
 
         #region Setting Bits
 
-        private IIRUnit ParseUnsigned8BitSet(string line, ref int instructionPointer)
+        private IIRUnit ParseUnsigned8BitSet(string[] tokens, ref int instructionPointer)
         {
-            var parameters = ParseParameters(line, "u8bitset");
-            var value = (byte)ParseIntegerLiteral(parameters[0]);
+            var value = (byte)ParseIntegerLiteral(tokens[1]);
             var result = new IRUnsigned8BitSet(instructionPointer, value);
             ++instructionPointer;
             return result;
         }
 
-        private IIRUnit ParseUnsigned16BitSet(string line, ref int instructionPointer)
+        private IIRUnit ParseUnsigned16BitSet(string[] tokens, ref int instructionPointer)
         {
-            var parameters = ParseParameters(line, "u16bitset");
-            var value = (ushort)ParseIntegerLiteral(parameters[0]);
+            var value = (ushort)ParseIntegerLiteral(tokens[1]);
             var result = new IRUnsigned16BitSet(instructionPointer, value);
             instructionPointer += 2;
             return result;
         }
 
-        private IIRUnit ParseUnsigned32BitSet(string line, ref int instructionPointer)
+        private IIRUnit ParseUnsigned32BitSet(string[] tokens, ref int instructionPointer)
         {
-            var parameters = ParseParameters(line, "u32bitset");
-            var value = (uint)ParseIntegerLiteral(parameters[0]);
+            var value = (uint)ParseIntegerLiteral(tokens[1]);
             var result = new IRUnsigned32BitSet(instructionPointer, value);
             instructionPointer += 4;
             return result;
@@ -269,28 +266,25 @@ namespace GekkoAssembler
 
         #region Unsetting Bits
 
-        private IIRUnit ParseUnsigned8BitUnset(string line, ref int instructionPointer)
+        private IIRUnit ParseUnsigned8BitUnset(string[] tokens, ref int instructionPointer)
         {
-            var parameters = ParseParameters(line, "u8bitunset");
-            var value = (byte)ParseIntegerLiteral(parameters[0]);
+            var value = (byte)ParseIntegerLiteral(tokens[1]);
             var result = new IRUnsigned8BitUnset(instructionPointer, value);
             ++instructionPointer;
             return result;
         }
 
-        private IIRUnit ParseUnsigned16BitUnset(string line, ref int instructionPointer)
+        private IIRUnit ParseUnsigned16BitUnset(string[] tokens, ref int instructionPointer)
         {
-            var parameters = ParseParameters(line, "u16bitunset");
-            var value = (ushort)ParseIntegerLiteral(parameters[0]);
+            var value = (ushort)ParseIntegerLiteral(tokens[1]);
             var result = new IRUnsigned16BitUnset(instructionPointer, value);
             instructionPointer += 2;
             return result;
         }
 
-        private IIRUnit ParseUnsigned32BitUnset(string line, ref int instructionPointer)
+        private IIRUnit ParseUnsigned32BitUnset(string[] tokens, ref int instructionPointer)
         {
-            var parameters = ParseParameters(line, "u32bitunset");
-            var value = (uint)ParseIntegerLiteral(parameters[0]);
+            var value = (uint)ParseIntegerLiteral(tokens[1]);
             var result = new IRUnsigned32BitUnset(instructionPointer, value);
             instructionPointer += 4;
             return result;
@@ -300,64 +294,57 @@ namespace GekkoAssembler
 
         #region Add
 
-        private IIRUnit ParseUnsigned8Add(string line, ref int instructionPointer)
+        private IIRUnit ParseUnsigned8Add(string[] tokens, ref int instructionPointer)
         {
-            var parameters = ParseParameters(line, "u8add");
-            var value = (byte)ParseIntegerLiteral(parameters[0]);
+            var value = (byte)ParseIntegerLiteral(tokens[1]);
             var result = new IRUnsigned8Add(instructionPointer, value);
             ++instructionPointer;
             return result;
         }
 
-        private IIRUnit ParseUnsigned16Add(string line, ref int instructionPointer)
+        private IIRUnit ParseUnsigned16Add(string[] tokens, ref int instructionPointer)
         {
-            var parameters = ParseParameters(line, "u16add");
-            var value = (ushort)ParseIntegerLiteral(parameters[0]);
+            var value = (ushort)ParseIntegerLiteral(tokens[1]);
             var result = new IRUnsigned16Add(instructionPointer, value);
             instructionPointer += 2;
             return result;
         }
 
-        private IIRUnit ParseUnsigned32Add(string line, ref int instructionPointer)
+        private IIRUnit ParseUnsigned32Add(string[] tokens, ref int instructionPointer)
         {
-            var parameters = ParseParameters(line, "u32add");
-            var value = (uint)ParseIntegerLiteral(parameters[0]);
+            var value = (uint)ParseIntegerLiteral(tokens[1]);
             var result = new IRUnsigned32Add(instructionPointer, value);
             instructionPointer += 4;
             return result;
         }
 
-        private IIRUnit ParseSigned8Add(string line, ref int instructionPointer)
+        private IIRUnit ParseSigned8Add(string[] tokens, ref int instructionPointer)
         {
-            var parameters = ParseParameters(line, "s8add");
-            var value = (sbyte)ParseIntegerLiteral(parameters[0]);
+            var value = (sbyte)ParseIntegerLiteral(tokens[1]);
             var result = new IRSigned8Add(instructionPointer, value);
             ++instructionPointer;
             return result;
         }
 
-        private IIRUnit ParseSigned16Add(string line, ref int instructionPointer)
+        private IIRUnit ParseSigned16Add(string[] tokens, ref int instructionPointer)
         {
-            var parameters = ParseParameters(line, "s16add");
-            var value = (short)ParseIntegerLiteral(parameters[0]);
+            var value = (short)ParseIntegerLiteral(tokens[1]);
             var result = new IRSigned16Add(instructionPointer, value);
             instructionPointer += 2;
             return result;
         }
 
-        private IIRUnit ParseSigned32Add(string line, ref int instructionPointer)
+        private IIRUnit ParseSigned32Add(string[] tokens, ref int instructionPointer)
         {
-            var parameters = ParseParameters(line, "s32add");
-            var value = ParseIntegerLiteral(parameters[0]);
+            var value = ParseIntegerLiteral(tokens[1]);
             var result = new IRSigned32Add(instructionPointer, value);
             instructionPointer += 4;
             return result;
         }
 
-        private IIRUnit ParseFloat32Add(string line, ref int instructionPointer)
+        private IIRUnit ParseFloat32Add(string[] tokens, ref int instructionPointer)
         {
-            var parameters = ParseParameters(line, "f32add");
-            var value = (float)ParseFloatLiteral(parameters[0]);
+            var value = (float)ParseFloatLiteral(tokens[1]);
             var result = new IRFloat32Add(instructionPointer, value);
             instructionPointer += 4;
             return result;
@@ -367,58 +354,51 @@ namespace GekkoAssembler
 
         #region Equal
 
-        private IIRUnit ParseUnsigned8Equal(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseUnsigned8Equal(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "u8equal");
-            var value = (byte)ParseIntegerLiteral(parameters[0]);
+            var value = (byte)ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRUnsigned8Equal(instructionPointer, value, block);
         }
 
-        private IIRUnit ParseUnsigned16Equal(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseUnsigned16Equal(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "u16equal");
-            var value = (ushort)ParseIntegerLiteral(parameters[0]);
+            var value = (ushort)ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRUnsigned16Equal(instructionPointer, value, block);
         }
 
-        private IIRUnit ParseUnsigned32Equal(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseUnsigned32Equal(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "u32equal");
-            var value = (uint)ParseIntegerLiteral(parameters[0]);
+            var value = (uint)ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRUnsigned32Equal(instructionPointer, value, block);
         }
 
-        private IIRUnit ParseSigned8Equal(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseSigned8Equal(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "s8equal");
-            var value = (sbyte)ParseIntegerLiteral(parameters[0]);
+            var value = (sbyte)ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRSigned8Equal(instructionPointer, value, block);
         }
 
-        private IIRUnit ParseSigned16Equal(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseSigned16Equal(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "s16equal");
-            var value = (short)ParseIntegerLiteral(parameters[0]);
+            var value = (short)ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRSigned16Equal(instructionPointer, value, block);
         }
 
-        private IIRUnit ParseSigned32Equal(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseSigned32Equal(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "s32equal");
-            var value = ParseIntegerLiteral(parameters[0]);
+            var value = ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRSigned32Equal(instructionPointer, value, block);
         }
 
-        private IIRUnit ParseFloat32Equal(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseFloat32Equal(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "f32equal");
-            var value = (float)ParseFloatLiteral(parameters[0]);
+            var value = (float)ParseFloatLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRFloat32Equal(instructionPointer, value, block);
         }
@@ -427,58 +407,51 @@ namespace GekkoAssembler
 
         #region Unequal
 
-        private IIRUnit ParseUnsigned8Unequal(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseUnsigned8Unequal(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "u8unequal");
-            var value = (byte)ParseIntegerLiteral(parameters[0]);
+            var value = (byte)ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRUnsigned8Unequal(instructionPointer, value, block);
         }
 
-        private IIRUnit ParseUnsigned16Unequal(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseUnsigned16Unequal(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "u16unequal");
-            var value = (ushort)ParseIntegerLiteral(parameters[0]);
+            var value = (ushort)ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRUnsigned16Unequal(instructionPointer, value, block);
         }
 
-        private IIRUnit ParseUnsigned32Unequal(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseUnsigned32Unequal(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "u32unequal");
-            var value = (uint)ParseIntegerLiteral(parameters[0]);
+            var value = (uint)ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRUnsigned32Unequal(instructionPointer, value, block);
         }
 
-        private IIRUnit ParseSigned8Unequal(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseSigned8Unequal(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "s8unequal");
-            var value = (sbyte)ParseIntegerLiteral(parameters[0]);
+            var value = (sbyte)ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRSigned8Unequal(instructionPointer, value, block);
         }
 
-        private IIRUnit ParseSigned16Unequal(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseSigned16Unequal(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "s16unequal");
-            var value = (short)ParseIntegerLiteral(parameters[0]);
+            var value = (short)ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRSigned16Unequal(instructionPointer, value, block);
         }
 
-        private IIRUnit ParseSigned32Unequal(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseSigned32Unequal(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "s32unequal");
-            var value = ParseIntegerLiteral(parameters[0]);
+            var value = ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRSigned32Unequal(instructionPointer, value, block);
         }
 
-        private IIRUnit ParseFloat32Unequal(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseFloat32Unequal(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "f32unequal");
-            var value = (float)ParseFloatLiteral(parameters[0]);
+            var value = (float)ParseFloatLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRFloat32Unequal(instructionPointer, value, block);
         }
@@ -487,58 +460,51 @@ namespace GekkoAssembler
 
         #region Less Than
 
-        private IIRUnit ParseUnsigned8LessThan(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseUnsigned8LessThan(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "u8lessthan");
-            var value = (byte)ParseIntegerLiteral(parameters[0]);
+            var value = (byte)ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRUnsigned8LessThan(instructionPointer, value, block);
         }
 
-        private IIRUnit ParseUnsigned16LessThan(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseUnsigned16LessThan(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "u16lessthan");
-            var value = (ushort)ParseIntegerLiteral(parameters[0]);
+            var value = (ushort)ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRUnsigned16LessThan(instructionPointer, value, block);
         }
 
-        private IIRUnit ParseUnsigned32LessThan(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseUnsigned32LessThan(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "u32lessthan");
-            var value = (uint)ParseIntegerLiteral(parameters[0]);
+            var value = (uint)ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRUnsigned32LessThan(instructionPointer, value, block);
         }
 
-        private IIRUnit ParseSigned8LessThan(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseSigned8LessThan(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "s8lessthan");
-            var value = (sbyte)ParseIntegerLiteral(parameters[0]);
+            var value = (sbyte)ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRSigned8LessThan(instructionPointer, value, block);
         }
 
-        private IIRUnit ParseSigned16LessThan(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseSigned16LessThan(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "s16lessthan");
-            var value = (short)ParseIntegerLiteral(parameters[0]);
+            var value = (short)ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRSigned16LessThan(instructionPointer, value, block);
         }
 
-        private IIRUnit ParseSigned32LessThan(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseSigned32LessThan(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "s32lessthan");
-            var value = ParseIntegerLiteral(parameters[0]);
+            var value = ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRSigned32LessThan(instructionPointer, value, block);
         }
 
-        private IIRUnit ParseFloat32LessThan(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseFloat32LessThan(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "f32lessthan");
-            var value = (float)ParseFloatLiteral(parameters[0]);
+            var value = (float)ParseFloatLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRFloat32LessThan(instructionPointer, value, block);
         }
@@ -547,58 +513,51 @@ namespace GekkoAssembler
 
         #region Greater Than
 
-        private IIRUnit ParseUnsigned8GreaterThan(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseUnsigned8GreaterThan(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "u8greaterthan");
-            var value = (byte)ParseIntegerLiteral(parameters[0]);
+            var value = (byte)ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRUnsigned8GreaterThan(instructionPointer, value, block);
         }
 
-        private IIRUnit ParseUnsigned16GreaterThan(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseUnsigned16GreaterThan(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "u16greaterthan");
-            var value = (ushort)ParseIntegerLiteral(parameters[0]);
+            var value = (ushort)ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRUnsigned16GreaterThan(instructionPointer, value, block);
         }
 
-        private IIRUnit ParseUnsigned32GreaterThan(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseUnsigned32GreaterThan(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "u32greaterthan");
-            var value = (uint)ParseIntegerLiteral(parameters[0]);
+            var value = (uint)ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRUnsigned32GreaterThan(instructionPointer, value, block);
         }
 
-        private IIRUnit ParseSigned8GreaterThan(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseSigned8GreaterThan(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "s8greaterthan");
-            var value = (sbyte)ParseIntegerLiteral(parameters[0]);
+            var value = (sbyte)ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRSigned8GreaterThan(instructionPointer, value, block);
         }
 
-        private IIRUnit ParseSigned16GreaterThan(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseSigned16GreaterThan(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "s16greaterthan");
-            var value = (short)ParseIntegerLiteral(parameters[0]);
+            var value = (short)ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRSigned16GreaterThan(instructionPointer, value, block);
         }
 
-        private IIRUnit ParseSigned32GreaterThan(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseSigned32GreaterThan(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "s32greaterthan");
-            var value = ParseIntegerLiteral(parameters[0]);
+            var value = ParseIntegerLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRSigned32GreaterThan(instructionPointer, value, block);
         }
 
-        private IIRUnit ParseFloat32GreaterThan(string line, int instructionPointer, Queue<string> lines)
+        private IIRUnit ParseFloat32GreaterThan(string[] tokens, int instructionPointer, Queue<string> lines)
         {
-            var parameters = ParseParameters(line, "f32greaterthan");
-            var value = (float)ParseFloatLiteral(parameters[0]);
+            var value = (float)ParseFloatLiteral(tokens[1]);
             var block = assembleAllLines(lines, instructionPointer);
             return new IRFloat32GreaterThan(instructionPointer, value, block);
         }
@@ -607,30 +566,32 @@ namespace GekkoAssembler
 
         private IRWriteData ParseDataSection(string line, int instructionPointer)
         {
-            if (line.StartsWith("str "))
-                return ParseStringDataSection(line, instructionPointer);
-            if (line.StartsWith("u8 "))
-                return ParseUnsigned8DataSection(line, instructionPointer);
-            if (line.StartsWith("u16 "))
-                return ParseUnsigned16DataSection(line, instructionPointer);
-            if (line.StartsWith("u32 "))
-                return ParseUnsigned32DataSection(line, instructionPointer);
-            if (line.StartsWith("u64 "))
-                return ParseUnsigned64DataSection(line, instructionPointer);
-            if (line.StartsWith("s8 "))
-                return ParseSigned8DataSection(line, instructionPointer);
-            if (line.StartsWith("s16 "))
-                return ParseSigned16DataSection(line, instructionPointer);
-            if (line.StartsWith("s32 "))
-                return ParseSigned32DataSection(line, instructionPointer);
-            if (line.StartsWith("s64 "))
-                return ParseSigned64DataSection(line, instructionPointer);
-            if (line.StartsWith("f32 "))
-                return ParseFloat32DataSection(line, instructionPointer);
-            if (line.StartsWith("f64 "))
-                return ParseFloat64DataSection(line, instructionPointer);
+            var tokens = TokenizeLine(line);
 
-            throw new ArgumentException($"The specified data section { line } is not supported.");
+            if (tokens[0] == "str")
+                return ParseStringDataSection(line, instructionPointer);
+            if (tokens[0] == "u8")
+                return ParseUnsigned8DataSection(tokens, instructionPointer);
+            if (tokens[0] == "u16")
+                return ParseUnsigned16DataSection(tokens, instructionPointer);
+            if (tokens[0] == "u32")
+                return ParseUnsigned32DataSection(tokens, instructionPointer);
+            if (tokens[0] == "u64")
+                return ParseUnsigned64DataSection(tokens, instructionPointer);
+            if (tokens[0] == "s8")
+                return ParseSigned8DataSection(tokens, instructionPointer);
+            if (tokens[0] == "s16")
+                return ParseSigned16DataSection(tokens, instructionPointer);
+            if (tokens[0] == "s32")
+                return ParseSigned32DataSection(tokens, instructionPointer);
+            if (tokens[0] == "s64")
+                return ParseSigned64DataSection(tokens, instructionPointer);
+            if (tokens[0] == "f32")
+                return ParseFloat32DataSection(tokens, instructionPointer);
+            if (tokens[0] == "f64")
+                return ParseFloat64DataSection(tokens, instructionPointer);
+
+            throw new ArgumentException($"The specified data section { tokens[0] } is not supported.");
         }
 
         #region Data Sections
@@ -647,73 +608,63 @@ namespace GekkoAssembler
             return literal.Substring(1, literal.Length - 2);
         }
 
-        private IRWriteData ParseUnsigned8DataSection(string line, int instructionPointer)
+        private IRWriteData ParseUnsigned8DataSection(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "u8");
-            var value = (byte)ParseIntegerLiteral(parameters[0]);
+            var value = (byte)ParseIntegerLiteral(tokens[1]);
             return new Unsigned8DataSection(instructionPointer, value);
         }
 
-        private IRWriteData ParseUnsigned16DataSection(string line, int instructionPointer)
+        private IRWriteData ParseUnsigned16DataSection(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "u16");
-            var value = (ushort)ParseIntegerLiteral(parameters[0]);
+            var value = (ushort)ParseIntegerLiteral(tokens[1]);
             return new Unsigned16DataSection(instructionPointer, value);
         }
 
-        private IRWriteData ParseUnsigned32DataSection(string line, int instructionPointer)
+        private IRWriteData ParseUnsigned32DataSection(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "u32");
-            var value = (uint)ParseIntegerLiteral(parameters[0]);
+            var value = (uint)ParseIntegerLiteral(tokens[1]);
             return new Unsigned32DataSection(instructionPointer, value);
         }
 
-        private IRWriteData ParseUnsigned64DataSection(string line, int instructionPointer)
+        private IRWriteData ParseUnsigned64DataSection(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "u64");
-            var value = (ulong)ParseInteger64Literal(parameters[0]);
+            var value = (ulong)ParseInteger64Literal(tokens[1]);
             return new Unsigned64DataSection(instructionPointer, value);
         }
 
-        private IRWriteData ParseSigned8DataSection(string line, int instructionPointer)
+        private IRWriteData ParseSigned8DataSection(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "s8");
-            var value = (sbyte)ParseIntegerLiteral(parameters[0]);
+            var value = (sbyte)ParseIntegerLiteral(tokens[1]);
             return new Signed8DataSection(instructionPointer, value);
         }
 
-        private IRWriteData ParseSigned16DataSection(string line, int instructionPointer)
+        private IRWriteData ParseSigned16DataSection(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "s16");
-            var value = (short)ParseIntegerLiteral(parameters[0]);
+            var value = (short)ParseIntegerLiteral(tokens[1]);
             return new Signed16DataSection(instructionPointer, value);
         }
 
-        private IRWriteData ParseSigned32DataSection(string line, int instructionPointer)
+        private IRWriteData ParseSigned32DataSection(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "s32");
-            var value = ParseIntegerLiteral(parameters[0]);
+            var value = ParseIntegerLiteral(tokens[1]);
             return new Signed32DataSection(instructionPointer, value);
         }
 
-        private IRWriteData ParseSigned64DataSection(string line, int instructionPointer)
+        private IRWriteData ParseSigned64DataSection(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "s64");
-            var value = ParseInteger64Literal(parameters[0]);
+            var value = ParseInteger64Literal(tokens[1]);
             return new Signed64DataSection(instructionPointer, value);
         }
 
-        private IRWriteData ParseFloat32DataSection(string line, int instructionPointer)
+        private IRWriteData ParseFloat32DataSection(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "f32");
-            var value = (float)ParseFloatLiteral(parameters[0]);
+            var value = (float)ParseFloatLiteral(tokens[1]);
             return new Float32DataSection(instructionPointer, value);
         }
 
-        private IRWriteData ParseFloat64DataSection(string line, int instructionPointer)
+        private IRWriteData ParseFloat64DataSection(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "f64");
-            var value = ParseFloatLiteral(parameters[0]);
+            var value = ParseFloatLiteral(tokens[1]);
             return new Float64DataSection(instructionPointer, value);
         }
 
@@ -721,259 +672,241 @@ namespace GekkoAssembler
 
         private GekkoInstruction ParseInstruction(string line, int instructionPointer)
         {
-            if (line.StartsWith("addi "))
-                return ParseInstructionADDI(line, instructionPointer);
-            if (line.StartsWith("addis "))
-                return ParseInstructionADDIS(line, instructionPointer);
-            if (line.StartsWith("b "))
-                return ParseInstructionB(line, instructionPointer);
-            if (line.StartsWith("ba "))
-                return ParseInstructionBA(line, instructionPointer);
-            if (line.StartsWith("bl "))
-                return ParseInstructionBL(line, instructionPointer);
-            if (line.StartsWith("bla "))
-                return ParseInstructionBLA(line, instructionPointer);
-            if (line.StartsWith("blr"))
-                return ParseInstructionBLR(line, instructionPointer);
-            if (line.StartsWith("crand "))
-                return ParseInstructionCRAND(line, instructionPointer);
-            if (line.StartsWith("crandc "))
-                return ParseInstructionCRANDC(line, instructionPointer);
-            if (line.StartsWith("crclr "))
-                return ParseInstructionCRCLR(line, instructionPointer);
-            if (line.StartsWith("creqv "))
-                return ParseInstructionCREQV(line, instructionPointer);
-            if (line.StartsWith("crmove "))
-                return ParseInstructionCRMOVE(line, instructionPointer);
-            if (line.StartsWith("crnand "))
-                return ParseInstructionCRNAND(line, instructionPointer);
-            if (line.StartsWith("crnor "))
-                return ParseInstructionCRNOR(line, instructionPointer);
-            if (line.StartsWith("crnot "))
-                return ParseInstructionCRNOT(line, instructionPointer);
-            if (line.StartsWith("cror "))
-                return ParseInstructionCROR(line, instructionPointer);
-            if (line.StartsWith("crorc "))
-                return ParseInstructionCRORC(line, instructionPointer);
-            if (line.StartsWith("crset "))
-                return ParseInstructionCRSET(line, instructionPointer);
-            if (line.StartsWith("crxor "))
-                return ParseInstructionCRXOR(line, instructionPointer);
-            if (line.StartsWith("divw "))
-                return ParseInstructionDIVW(line, instructionPointer);
-            if (line.StartsWith("icbi "))
-                return ParseInstructionICBI(line, instructionPointer);
-            if (line.StartsWith("isync"))
-                return ParseInstructionISYNC(instructionPointer);
-            if (line.StartsWith("lbz "))
-                return ParseInstructionLBZ(line, instructionPointer);
-            if (line.StartsWith("lfs "))
-                return ParseInstructionLFS(line, instructionPointer);
-            if (line.StartsWith("lhz "))
-                return ParseInstructionLHZ(line, instructionPointer);
-            if (line.StartsWith("lis "))
-                return ParseInstructionLIS(line, instructionPointer);
-            if (line.StartsWith("lwz "))
-                return ParseInstructionLWZ(line, instructionPointer);
-            if (line.StartsWith("mflr "))
-                return ParseInstructionMFLR(line, instructionPointer);
-            if (line.StartsWith("mfspr "))
-                return ParseInstructionMFSPR(line, instructionPointer);
-            if (line.StartsWith("mtlr "))
-                return ParseInstructionMTLR(line, instructionPointer);
-            if (line.StartsWith("mtspr "))
-                return ParseInstructionMTSPR(line, instructionPointer);
-            if (line.StartsWith("mulli "))
-                return ParseInstructionMULLI(line, instructionPointer);
-            if (line.StartsWith("mullw "))
-                return ParseInstructionMULLW(line, instructionPointer);
-            if (line.StartsWith("nop"))
-                return ParseInstructionNOP(line, instructionPointer);
-            if (line.StartsWith("ori "))
-                return ParseInstructionORI(line, instructionPointer);
-            if (line.StartsWith("stw "))
-                return ParseInstructionSTW(line, instructionPointer);
-            if (line.StartsWith("stwu "))
-                return ParseInstructionSTWU(line, instructionPointer);
-            if (line.StartsWith("sub "))
-                return ParseInstructionSUB(line, instructionPointer);
-            if (line.StartsWith("subf "))
-                return ParseInstructionSUBF(line, instructionPointer);
+            var tokens = TokenizeLine(line);
 
-            throw new ArgumentException($"The specified instruction { line } is not supported.");
+            if (tokens[0] == "addi")
+                return ParseInstructionADDI(tokens, instructionPointer);
+            if (tokens[0] == "addis")
+                return ParseInstructionADDIS(tokens, instructionPointer);
+            if (tokens[0] == "b")
+                return ParseInstructionB(tokens, instructionPointer);
+            if (tokens[0] == "ba")
+                return ParseInstructionBA(tokens, instructionPointer);
+            if (tokens[0] == "bl")
+                return ParseInstructionBL(tokens, instructionPointer);
+            if (tokens[0] == "bla")
+                return ParseInstructionBLA(tokens, instructionPointer);
+            if (tokens[0] == "blr")
+                return ParseInstructionBLR(instructionPointer);
+            if (tokens[0] == "crand")
+                return ParseInstructionCRAND(tokens, instructionPointer);
+            if (tokens[0] == "crandc")
+                return ParseInstructionCRANDC(tokens, instructionPointer);
+            if (tokens[0] == "crclr")
+                return ParseInstructionCRCLR(tokens, instructionPointer);
+            if (tokens[0] == "creqv")
+                return ParseInstructionCREQV(tokens, instructionPointer);
+            if (tokens[0] == "crmove")
+                return ParseInstructionCRMOVE(tokens, instructionPointer);
+            if (tokens[0] == "crnand")
+                return ParseInstructionCRNAND(tokens, instructionPointer);
+            if (tokens[0] == "crnor")
+                return ParseInstructionCRNOR(tokens, instructionPointer);
+            if (tokens[0] == "crnot")
+                return ParseInstructionCRNOT(tokens, instructionPointer);
+            if (tokens[0] == "cror")
+                return ParseInstructionCROR(tokens, instructionPointer);
+            if (tokens[0] == "crorc")
+                return ParseInstructionCRORC(tokens, instructionPointer);
+            if (tokens[0] == "crset")
+                return ParseInstructionCRSET(tokens, instructionPointer);
+            if (tokens[0] == "crxor")
+                return ParseInstructionCRXOR(tokens, instructionPointer);
+            if (tokens[0] == "divw")
+                return ParseInstructionDIVW(tokens, instructionPointer);
+            if (tokens[0] == "icbi")
+                return ParseInstructionICBI(tokens, instructionPointer);
+            if (tokens[0] == "isync")
+                return ParseInstructionISYNC(instructionPointer);
+            if (tokens[0] == "lbz")
+                return ParseInstructionLBZ(tokens, instructionPointer);
+            if (tokens[0] == "lfs")
+                return ParseInstructionLFS(tokens, instructionPointer);
+            if (tokens[0] == "lhz")
+                return ParseInstructionLHZ(tokens, instructionPointer);
+            if (tokens[0] == "lis")
+                return ParseInstructionLIS(tokens, instructionPointer);
+            if (tokens[0] == "lwz")
+                return ParseInstructionLWZ(tokens, instructionPointer);
+            if (tokens[0] == "mflr")
+                return ParseInstructionMFLR(tokens, instructionPointer);
+            if (tokens[0] == "mfspr")
+                return ParseInstructionMFSPR(tokens, instructionPointer);
+            if (tokens[0] == "mtlr")
+                return ParseInstructionMTLR(tokens, instructionPointer);
+            if (tokens[0] == "mtspr")
+                return ParseInstructionMTSPR(tokens, instructionPointer);
+            if (tokens[0] == "mulli")
+                return ParseInstructionMULLI(tokens, instructionPointer);
+            if (tokens[0] == "mullw")
+                return ParseInstructionMULLW(tokens, instructionPointer);
+            if (tokens[0] == "nop")
+                return ParseInstructionNOP(instructionPointer);
+            if (tokens[0] == "ori")
+                return ParseInstructionORI(tokens, instructionPointer);
+            if (tokens[0] == "stw")
+                return ParseInstructionSTW(tokens, instructionPointer);
+            if (tokens[0] == "stwu")
+                return ParseInstructionSTWU(tokens, instructionPointer);
+            if (tokens[0] == "sub")
+                return ParseInstructionSUB(tokens, instructionPointer);
+            if (tokens[0] == "subf")
+                return ParseInstructionSUBF(tokens, instructionPointer);
+
+            throw new ArgumentException($"The specified instruction { tokens[0] } is not supported.");
         }
 
         #region Gekko Instructions
 
-        private GekkoInstruction ParseInstructionADDI(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionADDI(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "addi");
-            var rd = ParseRegister(parameters[0]);
-            var ra = ParseRegister(parameters[1]);
-            var simm = ParseIntegerLiteral(parameters[2]);
+            var rd = ParseRegister(tokens[1]);
+            var ra = ParseRegister(tokens[2]);
+            var simm = ParseIntegerLiteral(tokens[3]);
             return new AddImmediateInstruction(instructionPointer, rd, ra, simm);
         }
 
-        private GekkoInstruction ParseInstructionADDIS(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionADDIS(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "addis");
-            var rd = ParseRegister(parameters[0]);
-            var ra = ParseRegister(parameters[1]);
-            var simm = ParseIntegerLiteral(parameters[2]);
+            var rd = ParseRegister(tokens[1]);
+            var ra = ParseRegister(tokens[2]);
+            var simm = ParseIntegerLiteral(tokens[3]);
             return new AddImmediateShiftedInstruction(instructionPointer, rd, ra, simm);
         }
 
-        private GekkoInstruction ParseInstructionB(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionB(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "b");
-            var targetAddress = ParseIntegerLiteral(parameters[0]);
+            var targetAddress = ParseIntegerLiteral(tokens[1]);
             return new BranchInstruction(instructionPointer, targetAddress, false, false);
         }
 
-        private GekkoInstruction ParseInstructionBA(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionBA(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "ba");
-            var targetAddress = ParseIntegerLiteral(parameters[0]);
+            var targetAddress = ParseIntegerLiteral(tokens[1]);
             return new BranchInstruction(instructionPointer, targetAddress, true, false);
         }
 
-        private GekkoInstruction ParseInstructionBL(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionBL(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "bl");
-            var targetAddress = ParseIntegerLiteral(parameters[0]);
+            var targetAddress = ParseIntegerLiteral(tokens[1]);
             return new BranchInstruction(instructionPointer, targetAddress, false, true);
         }
 
-        private GekkoInstruction ParseInstructionBLA(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionBLA(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "bla");
-            var targetAddress = ParseIntegerLiteral(parameters[0]);
+            var targetAddress = ParseIntegerLiteral(tokens[1]);
             return new BranchInstruction(instructionPointer, targetAddress, true, true);
         }
 
-        private GekkoInstruction ParseInstructionBLR(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionBLR(int instructionPointer)
         {
             return new BranchToLinkRegisterInstruction(instructionPointer);
         }
 
-        private GekkoInstruction ParseInstructionCRAND(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionCRAND(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "crand");
-            var crbd = ParseConditionRegister(parameters[0]);
-            var crba = ParseConditionRegister(parameters[1]);
-            var crbb = ParseConditionRegister(parameters[2]);
+            var crbd = ParseConditionRegister(tokens[1]);
+            var crba = ParseConditionRegister(tokens[2]);
+            var crbb = ParseConditionRegister(tokens[3]);
             return new ConditionRegisterANDInstruction(instructionPointer, crbd, crba, crbb);
         }
 
-        private GekkoInstruction ParseInstructionCRANDC(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionCRANDC(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "crandc");
-            var crbd = ParseConditionRegister(parameters[0]);
-            var crba = ParseConditionRegister(parameters[1]);
-            var crbb = ParseConditionRegister(parameters[2]);
+            var crbd = ParseConditionRegister(tokens[1]);
+            var crba = ParseConditionRegister(tokens[2]);
+            var crbb = ParseConditionRegister(tokens[3]);
             return new ConditionRegisterANDComplementInstruction(instructionPointer, crbd, crba, crbb);
         }
 
-        private GekkoInstruction ParseInstructionCRCLR(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionCRCLR(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "crclr");
-            var crbd = ParseConditionRegister(parameters[0]);
+            var crbd = ParseConditionRegister(tokens[1]);
             return new ConditionRegisterClearInstruction(instructionPointer, crbd);
         }
 
-        private GekkoInstruction ParseInstructionCREQV(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionCREQV(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "creqv");
-            var crbd = ParseConditionRegister(parameters[0]);
-            var crba = ParseConditionRegister(parameters[1]);
-            var crbb = ParseConditionRegister(parameters[2]);
+            var crbd = ParseConditionRegister(tokens[1]);
+            var crba = ParseConditionRegister(tokens[2]);
+            var crbb = ParseConditionRegister(tokens[3]);
             return new ConditionRegisterEquivalentInstruction(instructionPointer, crbd, crba, crbb);
         }
 
         // Simplified mnemonic of CROR
-        private GekkoInstruction ParseInstructionCRMOVE(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionCRMOVE(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "crmove");
-            var crbd = ParseConditionRegister(parameters[0]);
-            var crba = ParseConditionRegister(parameters[1]);
+            var crbd = ParseConditionRegister(tokens[1]);
+            var crba = ParseConditionRegister(tokens[2]);
             return new ConditionRegisterORInstruction(instructionPointer, crbd, crba, crba);
         }
 
-        private GekkoInstruction ParseInstructionCRNAND(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionCRNAND(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "crnand");
-            var crbd = ParseConditionRegister(parameters[0]);
-            var crba = ParseConditionRegister(parameters[1]);
-            var crbb = ParseConditionRegister(parameters[2]);
+            var crbd = ParseConditionRegister(tokens[1]);
+            var crba = ParseConditionRegister(tokens[2]);
+            var crbb = ParseConditionRegister(tokens[3]);
             return new ConditionRegisterNANDInstruction(instructionPointer, crbd, crba, crbb);
         }
 
-        private GekkoInstruction ParseInstructionCRNOR(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionCRNOR(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "crnor");
-            var crbd = ParseConditionRegister(parameters[0]);
-            var crba = ParseConditionRegister(parameters[1]);
-            var crbb = ParseConditionRegister(parameters[2]);
+            var crbd = ParseConditionRegister(tokens[1]);
+            var crba = ParseConditionRegister(tokens[2]);
+            var crbb = ParseConditionRegister(tokens[3]);
             return new ConditionRegisterNORInstruction(instructionPointer, crbd, crba, crbb);
         }
 
         // Simplified mnemonic of CRNOR
-        private GekkoInstruction ParseInstructionCRNOT(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionCRNOT(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "crnot");
-            var crbd = ParseConditionRegister(parameters[0]);
-            var crba = ParseConditionRegister(parameters[1]);
+            var crbd = ParseConditionRegister(tokens[1]);
+            var crba = ParseConditionRegister(tokens[2]);
             return new ConditionRegisterNORInstruction(instructionPointer, crbd, crba, crba);
         }
 
-        private GekkoInstruction ParseInstructionCROR(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionCROR(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "cror");
-            var crbd = ParseConditionRegister(parameters[0]);
-            var crba = ParseConditionRegister(parameters[1]);
-            var crbb = ParseConditionRegister(parameters[2]);
+            var crbd = ParseConditionRegister(tokens[1]);
+            var crba = ParseConditionRegister(tokens[2]);
+            var crbb = ParseConditionRegister(tokens[3]);
             return new ConditionRegisterORInstruction(instructionPointer, crbd, crba, crbb);
         }
 
-        private GekkoInstruction ParseInstructionCRORC(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionCRORC(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "crorc");
-            var crbd = ParseConditionRegister(parameters[0]);
-            var crba = ParseConditionRegister(parameters[1]);
-            var crbb = ParseConditionRegister(parameters[2]);
+            var crbd = ParseConditionRegister(tokens[1]);
+            var crba = ParseConditionRegister(tokens[2]);
+            var crbb = ParseConditionRegister(tokens[3]);
             return new ConditionRegisterORComplementInstruction(instructionPointer, crbd, crba, crbb);
         }
 
-        private GekkoInstruction ParseInstructionCRSET(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionCRSET(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "crset");
-            var crbd = ParseConditionRegister(parameters[0]);
+            var crbd = ParseConditionRegister(tokens[1]);
             return new ConditionRegisterSetInstruction(instructionPointer, crbd);
         }
 
-        private GekkoInstruction ParseInstructionCRXOR(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionCRXOR(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "crxor");
-            var crbd = ParseConditionRegister(parameters[0]);
-            var crba = ParseConditionRegister(parameters[1]);
-            var crbb = ParseConditionRegister(parameters[2]);
+            var crbd = ParseConditionRegister(tokens[1]);
+            var crba = ParseConditionRegister(tokens[2]);
+            var crbb = ParseConditionRegister(tokens[3]);
             return new ConditionRegisterXORInstruction(instructionPointer, crbd, crba, crbb);
         }
 
-        private GekkoInstruction ParseInstructionDIVW(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionDIVW(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "divw");
-            var rd = ParseRegister(parameters[0]);
-            var ra = ParseRegister(parameters[1]);
-            var rb = ParseRegister(parameters[2]);
+            var rd = ParseRegister(tokens[1]);
+            var ra = ParseRegister(tokens[2]);
+            var rb = ParseRegister(tokens[3]);
             return new DivideWordInstruction(instructionPointer, rd, ra, rb, false, false);
         }
 
-        private GekkoInstruction ParseInstructionICBI(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionICBI(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "icbi");
-            var ra = ParseRegister(parameters[0]);
-            var rb = ParseRegister(parameters[1]);
+            var ra = ParseRegister(tokens[1]);
+            var rb = ParseRegister(tokens[2]);
             return new InstructionCacheBlockInvalidateInstruction(instructionPointer, ra, rb);
         }
 
@@ -982,145 +915,129 @@ namespace GekkoAssembler
             return new InstructionSynchronizeInstruction(instructionPointer);
         }
 
-        private GekkoInstruction ParseInstructionLBZ(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionLBZ(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "lbz");
-            var rd = ParseRegister(parameters[0]);
-            var offset = ParseIntegerLiteral(parameters[1]);
-            var ra = ParseRegister(parameters[2]);
+            var rd = ParseRegister(tokens[1]);
+            var offset = ParseIntegerLiteral(tokens[2]);
+            var ra = ParseRegister(tokens[3]);
             return new LoadByteAndZeroInstruction(instructionPointer, rd, ra, offset);
         }
 
-        private GekkoInstruction ParseInstructionLFS(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionLFS(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "lfs");
-            var rd = ParseRegister(parameters[0]);
-            var offset = ParseIntegerLiteral(parameters[1]);
-            var ra = ParseRegister(parameters[2]);
+            var rd = ParseRegister(tokens[1]);
+            var offset = ParseIntegerLiteral(tokens[2]);
+            var ra = ParseRegister(tokens[3]);
             return new LoadFloatingPointSingleInstruction(instructionPointer, rd, ra, offset);
         }
 
-        private GekkoInstruction ParseInstructionLHZ(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionLHZ(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "lhz");
-            var rd = ParseRegister(parameters[0]);
-            var offset = ParseIntegerLiteral(parameters[1]);
-            var ra = ParseRegister(parameters[2]);
+            var rd = ParseRegister(tokens[1]);
+            var offset = ParseIntegerLiteral(tokens[2]);
+            var ra = ParseRegister(tokens[3]);
             return new LoadHalfWordAndZeroInstruction(instructionPointer, rd, ra, offset);
         }
 
-        private GekkoInstruction ParseInstructionLIS(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionLIS(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "lis");
-            var rd = ParseRegister(parameters[0]);
-            var simm = ParseIntegerLiteral(parameters[1]);
+            var rd = ParseRegister(tokens[1]);
+            var simm = ParseIntegerLiteral(tokens[2]);
             return new LoadImmediateShiftedInstruction(instructionPointer, rd, simm);
         }
 
-        private GekkoInstruction ParseInstructionLWZ(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionLWZ(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "lwz");
-            var rd = ParseRegister(parameters[0]);
-            var offset = ParseIntegerLiteral(parameters[1]);
-            var ra = ParseRegister(parameters[2]);
+            var rd = ParseRegister(tokens[1]);
+            var offset = ParseIntegerLiteral(tokens[2]);
+            var ra = ParseRegister(tokens[3]);
             return new LoadWordAndZeroInstruction(instructionPointer, rd, ra, offset);
         }
 
-        private GekkoInstruction ParseInstructionMFLR(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionMFLR(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "mflr");
-            var rd = ParseRegister(parameters[0]);
+            var rd = ParseRegister(tokens[1]);
             return new MoveFromLinkRegisterInstruction(instructionPointer, rd);
         }
 
-        private GekkoInstruction ParseInstructionMFSPR(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionMFSPR(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "mfspr");
-            var rd = ParseRegister(parameters[0]);
-            var spr = ParseIntegerLiteral(parameters[1]);
+            var rd = ParseRegister(tokens[1]);
+            var spr = ParseIntegerLiteral(tokens[2]);
             return new MoveFromSpecialPurposeRegisterInstruction(instructionPointer, rd, spr);
         }
 
-        private GekkoInstruction ParseInstructionMTLR(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionMTLR(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "mtlr");
-            var rs = ParseRegister(parameters[0]);
+            var rs = ParseRegister(tokens[1]);
             return new MoveToLinkRegisterInstruction(instructionPointer, rs);
         }
 
-        private GekkoInstruction ParseInstructionMTSPR(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionMTSPR(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "mtspr");
-            var spr = ParseIntegerLiteral(parameters[0]);
-            var rs = ParseRegister(parameters[1]);
+            var spr = ParseIntegerLiteral(tokens[1]);
+            var rs = ParseRegister(tokens[2]);
             return new MoveToSpecialPurposeRegisterInstruction(instructionPointer, spr, rs);
         }
 
-        private GekkoInstruction ParseInstructionMULLI(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionMULLI(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "mulli");
-            var rd = ParseRegister(parameters[0]);
-            var ra = ParseRegister(parameters[1]);
-            var simm = ParseIntegerLiteral(parameters[2]);
+            var rd = ParseRegister(tokens[1]);
+            var ra = ParseRegister(tokens[2]);
+            var simm = ParseIntegerLiteral(tokens[3]);
             return new MultiplyLowImmediateInstruction(instructionPointer, rd, ra, simm);
         }
 
-        private GekkoInstruction ParseInstructionMULLW(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionMULLW(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "mullw");
-            var rd = ParseRegister(parameters[0]);
-            var ra = ParseRegister(parameters[1]);
-            var rb = ParseRegister(parameters[2]);
+            var rd = ParseRegister(tokens[1]);
+            var ra = ParseRegister(tokens[2]);
+            var rb = ParseRegister(tokens[3]);
             return new MultiplyLowWordInstruction(instructionPointer, rd, ra, rb, false, false);
         }
 
-        private GekkoInstruction ParseInstructionNOP(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionNOP(int instructionPointer)
         {
             return new NoOperationInstruction(instructionPointer);
         }
 
-        private GekkoInstruction ParseInstructionORI(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionORI(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "ori");
-            var ra = ParseRegister(parameters[0]);
-            var rs = ParseRegister(parameters[1]);
-            var uimm = ParseIntegerLiteral(parameters[2]);
+            var ra = ParseRegister(tokens[1]);
+            var rs = ParseRegister(tokens[2]);
+            var uimm = ParseIntegerLiteral(tokens[3]);
             return new OrImmediateInstruction(instructionPointer, ra, rs, uimm);
         }
 
-        private GekkoInstruction ParseInstructionSTW(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionSTW(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "stw");
-            var rs = ParseRegister(parameters[0]);
-            var offset = ParseIntegerLiteral(parameters[1]);
-            var ra = ParseRegister(parameters[2]);
+            var rs = ParseRegister(tokens[1]);
+            var offset = ParseIntegerLiteral(tokens[2]);
+            var ra = ParseRegister(tokens[3]);
             return new StoreWordInstruction(instructionPointer, rs, offset, ra);
         }
 
-        private GekkoInstruction ParseInstructionSTWU(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionSTWU(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "stwu");
-            var rs = ParseRegister(parameters[0]);
-            var offset = ParseIntegerLiteral(parameters[1]);
-            var ra = ParseRegister(parameters[2]);
+            var rs = ParseRegister(tokens[1]);
+            var offset = ParseIntegerLiteral(tokens[2]);
+            var ra = ParseRegister(tokens[3]);
             return new StoreWordWithUpdateInstruction(instructionPointer, rs, offset, ra);
         }
 
-        private GekkoInstruction ParseInstructionSUB(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionSUB(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "sub");
-            var rd = ParseRegister(parameters[0]);
-            var ra = ParseRegister(parameters[1]);
-            var rb = ParseRegister(parameters[2]);
+            var rd = ParseRegister(tokens[1]);
+            var ra = ParseRegister(tokens[2]);
+            var rb = ParseRegister(tokens[3]);
             return new SubtractFromInstruction(instructionPointer, rd, rb, ra, false, false);
         }
 
-        private GekkoInstruction ParseInstructionSUBF(string line, int instructionPointer)
+        private GekkoInstruction ParseInstructionSUBF(string[] tokens, int instructionPointer)
         {
-            var parameters = ParseParameters(line, "subf");
-            var rd = ParseRegister(parameters[0]);
-            var ra = ParseRegister(parameters[1]);
-            var rb = ParseRegister(parameters[2]);
+            var rd = ParseRegister(tokens[1]);
+            var ra = ParseRegister(tokens[2]);
+            var rb = ParseRegister(tokens[3]);
             return new SubtractFromInstruction(instructionPointer, rd, ra, rb, false, false);
         }
 
@@ -1146,11 +1063,6 @@ namespace GekkoAssembler
         private int ParseConditionRegister(string register)
         {
             return ParseIntegerLiteral(register.Substring(3));
-        }
-
-        private string[] ParseParameters(string line, string op)
-        {
-            return line.Substring(op.Length).Replace(" ", "").Replace("\t", "").Replace(")","").Split(',', '(');
         }
 
         private int ParseInstructionPointerLabel(string line)
@@ -1184,6 +1096,11 @@ namespace GekkoAssembler
         private double ParseFloatLiteral(string literal)
         {
             return double.Parse(literal, CultureInfo.InvariantCulture);
+        }
+
+        private static string[] TokenizeLine(string line)
+        {
+            return Regex.Replace(line, "[\t,()]", " ").Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).Select(token => token.Trim()).ToArray();
         }
     }
 }


### PR DESCRIPTION
Gets rid of the spaces and repeated redeclarations of the same instruction name again via parse parameters (this will also make it less of a pain to support instruction variants that use 'o' or '.' at the end of their name.
