### PR TITLE
Assembler: Add missing ADDEO variant

### DIFF
--- a/GekkoAssembler.Common/Assembler.cs
+++ b/GekkoAssembler.Common/Assembler.cs
@@ -25,6 +25,7 @@ namespace GekkoAssembler
             {"adde"   , ParseInstructionADDE   },
             {"adde."  , ParseInstructionADDE   },
             {"addeo"  , ParseInstructionADDE   },
+            {"addeo." , ParseInstructionADDE   },
             {"addi"   , ParseInstructionADDI   },
             {"addis"  , ParseInstructionADDIS  },
             {"addme"  , ParseInstructionADDME  },


### PR DESCRIPTION
Basically, I shouldn't do things with single character margins of error late at night. 
