### PR TITLE
GekkoInstruction: reify the Address getter

### DIFF
--- a/GekkoAssembler.Common/GekkoInstructions/AddCarryingInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/AddCarryingInstruction.cs
@@ -2,12 +2,10 @@
 {
     public sealed class AddCarryingInstruction : GekkoInstruction
     {
-        public override int Address  { get; }
         public override int ByteCode { get; }
 
-        public AddCarryingInstruction(int address, int rD, int rA, int rB, bool oe, bool rc)
+        public AddCarryingInstruction(int address, int rD, int rA, int rB, bool oe, bool rc) : base(address)
         {
-            this.Address = address;
             this.ByteCode = (31 << 26 | rD << 21 | rA << 16 | rB << 11 | (oe ? 1 : 0) << 10 | 10 << 1 | (rc ? 1 : 0));
         }
     }

--- a/GekkoAssembler.Common/GekkoInstructions/AddExtendedInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/AddExtendedInstruction.cs
@@ -2,12 +2,10 @@
 {
     public sealed class AddExtendedInstruction : GekkoInstruction
     {
-        public override int Address  { get; }
         public override int ByteCode { get; }
 
-        public AddExtendedInstruction(int address, int rD, int rA, int rB, bool oe, bool rc)
+        public AddExtendedInstruction(int address, int rD, int rA, int rB, bool oe, bool rc) : base(address)
         {
-            this.Address = address;
             this.ByteCode = (31 << 26 | rD << 21 | rA << 16 | rB << 11 | (oe ? 1 : 0) << 10 | 138 << 1 | (rc ? 1 : 0));
         }
     }

--- a/GekkoAssembler.Common/GekkoInstructions/AddImmediateInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/AddImmediateInstruction.cs
@@ -2,7 +2,6 @@
 {
     public class AddImmediateInstruction : GekkoInstruction
     {
-        public override int Address { get; }
         public override int ByteCode
             => (((((14 << 5) | RegisterDestination) << 5) | RegisterA) << 16) | (SIMM & 0xFFFF);
 
@@ -10,9 +9,8 @@
         public int RegisterA { get; }
         public int SIMM { get; }
 
-        public AddImmediateInstruction(int address, int registerDestination, int registerA, int simm)
+        public AddImmediateInstruction(int address, int registerDestination, int registerA, int simm) : base(address)
         {
-            Address = address;
             RegisterDestination = registerDestination;
             RegisterA = registerA;
             SIMM = simm;

--- a/GekkoAssembler.Common/GekkoInstructions/AddImmediateShiftedInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/AddImmediateShiftedInstruction.cs
@@ -2,7 +2,6 @@
 {
     public class AddImmediateShiftedInstruction : GekkoInstruction
     {
-        public override int Address { get; }
         public override int ByteCode
             => (((((15 << 5) | RegisterDestination) << 5) | RegisterA) << 16) | (SIMM & 0xFFFF);
 
@@ -10,9 +9,8 @@
         public int RegisterA { get; }
         public int SIMM { get; }
 
-        public AddImmediateShiftedInstruction(int address, int registerDestination, int registerA, int simm)
+        public AddImmediateShiftedInstruction(int address, int registerDestination, int registerA, int simm) : base(address)
         {
-            Address = address;
             RegisterDestination = registerDestination;
             RegisterA = registerA;
             SIMM = simm;

--- a/GekkoAssembler.Common/GekkoInstructions/AddInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/AddInstruction.cs
@@ -2,12 +2,10 @@
 {
     public sealed class AddInstruction : GekkoInstruction
     {
-        public override int Address  { get; }
         public override int ByteCode { get; }
 
-        public AddInstruction(int address, int rD, int rA, int rB, bool oe, bool rc)
+        public AddInstruction(int address, int rD, int rA, int rB, bool oe, bool rc) : base(address)
         {
-            this.Address = address;
             this.ByteCode = (31 << 26 | rD << 21 | rA << 16 | rB << 11 | (oe ? 1 : 0) << 10 | 266 << 1 | (rc ? 1 : 0));
         }
     }

--- a/GekkoAssembler.Common/GekkoInstructions/AddToMinusOneExtendedInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/AddToMinusOneExtendedInstruction.cs
@@ -2,12 +2,10 @@
 {
     public sealed class AddToMinusOneExtendedInstruction : GekkoInstruction
     {
-        public override int Address  { get; }
         public override int ByteCode { get; }
 
-        public AddToMinusOneExtendedInstruction(int address, int rD, int rA, bool oe, bool rc)
+        public AddToMinusOneExtendedInstruction(int address, int rD, int rA, bool oe, bool rc) : base(address)
         {
-            this.Address  = address;
             this.ByteCode = (31 << 26 | rD << 21 | rA << 16 | (oe ? 1 : 0) << 10 | 234 << 1 | (rc ? 1 : 0));
         }
     }

--- a/GekkoAssembler.Common/GekkoInstructions/AddToZeroExtendedInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/AddToZeroExtendedInstruction.cs
@@ -2,12 +2,10 @@
 {
     public sealed class AddToZeroExtendedInstruction : GekkoInstruction
     {
-        public override int Address  { get; }
         public override int ByteCode { get; }
 
-        public AddToZeroExtendedInstruction(int address, int rD, int rA, bool oe, bool rc)
+        public AddToZeroExtendedInstruction(int address, int rD, int rA, bool oe, bool rc) : base(address)
         {
-            this.Address = address;
             this.ByteCode = (31 << 26 | rD << 21 | rA << 16 | (oe ? 1 : 0) << 10 | 202 << 1 | (rc ? 1 : 0));
         }
     }

--- a/GekkoAssembler.Common/GekkoInstructions/AndInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/AndInstruction.cs
@@ -2,12 +2,10 @@
 {
     public sealed class AndInstruction : GekkoInstruction
     {
-        public override int Address  { get; }
         public override int ByteCode { get; }
 
-        public AndInstruction(int address, int rA, int rS, int rB, bool rc)
+        public AndInstruction(int address, int rA, int rS, int rB, bool rc) : base(address)
         {
-            this.Address = address;
             this.ByteCode = (31 << 26 | rS << 21 | rA << 16 | rB << 11 | 28 << 1 | (rc ? 1 : 0));
         }
     }

--- a/GekkoAssembler.Common/GekkoInstructions/BranchInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/BranchInstruction.cs
@@ -2,7 +2,6 @@
 {
     public class BranchInstruction : GekkoInstruction
     {
-        public override int Address { get; }
         public override int ByteCode
             => (18 << 26) | (0x3FFFFFC & (AA ? TargetAddress : (TargetAddress - Address))) | ((AA ? 1 : 0) << 1) | (LK ? 1 : 0);
 
@@ -10,9 +9,8 @@
         public bool AA { get; }
         public bool LK { get; }
 
-        public BranchInstruction(int address, int targetAddress, bool aa = false, bool lk = false)
+        public BranchInstruction(int address, int targetAddress, bool aa = false, bool lk = false) : base(address)
         {
-            Address = address;
             TargetAddress = targetAddress;
             AA = aa;
             LK = lk;

--- a/GekkoAssembler.Common/GekkoInstructions/BranchToLinkRegisterInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/BranchToLinkRegisterInstruction.cs
@@ -2,12 +2,10 @@
 {
     public class BranchToLinkRegisterInstruction : GekkoInstruction
     {
-        public override int Address { get; }
         public override int ByteCode => 0x4E800020;
 
-        public BranchToLinkRegisterInstruction(int address)
+        public BranchToLinkRegisterInstruction(int address) : base(address)
         {
-            Address = address;
         }
     }
 }

--- a/GekkoAssembler.Common/GekkoInstructions/ConditionRegisterANDComplementInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/ConditionRegisterANDComplementInstruction.cs
@@ -2,12 +2,10 @@
 {
     public sealed class ConditionRegisterANDComplementInstruction : GekkoInstruction
     {
-        public override int Address  { get; }
         public override int ByteCode { get; }
 
-        public ConditionRegisterANDComplementInstruction(int address, int crD, int crA, int crB)
+        public ConditionRegisterANDComplementInstruction(int address, int crD, int crA, int crB) : base(address)
         {
-            this.Address = address;
             this.ByteCode = (19 << 26 | crD << 21 | crA << 16 | crB << 11 | 129 << 1);
         }
     }

--- a/GekkoAssembler.Common/GekkoInstructions/ConditionRegisterANDInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/ConditionRegisterANDInstruction.cs
@@ -2,12 +2,10 @@
 {
     public sealed class ConditionRegisterANDInstruction : GekkoInstruction
     {
-        public override int Address  { get; }
         public override int ByteCode { get; }
 
-        public ConditionRegisterANDInstruction(int address, int crD, int crA, int crB)
+        public ConditionRegisterANDInstruction(int address, int crD, int crA, int crB) : base(address)
         {
-            this.Address = address;
             this.ByteCode = (19 << 26 | crD << 21 | crA << 16 | crB << 11 | 257 << 1);
         }
     }

--- a/GekkoAssembler.Common/GekkoInstructions/ConditionRegisterEquivalentInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/ConditionRegisterEquivalentInstruction.cs
@@ -2,7 +2,6 @@
 {
     public class ConditionRegisterEquivalentInstruction : GekkoInstruction
     {
-        public override int Address { get; }
         public override int ByteCode
             => (((((((((19 << 5) | ConditionRegisterDestination) << 5) | ConditionRegisterA) << 5) | ConditionRegisterB) << 10) | 289) << 1);
 
@@ -10,9 +9,8 @@
         public int ConditionRegisterA { get; }
         public int ConditionRegisterB { get; }
 
-        public ConditionRegisterEquivalentInstruction(int address, int conditionRegisterDestination, int conditionRegisterA, int conditionRegisterB)
+        public ConditionRegisterEquivalentInstruction(int address, int conditionRegisterDestination, int conditionRegisterA, int conditionRegisterB) : base(address)
         {
-            Address = address;
             ConditionRegisterDestination = conditionRegisterDestination;
             ConditionRegisterA = conditionRegisterA;
             ConditionRegisterB = conditionRegisterB;

--- a/GekkoAssembler.Common/GekkoInstructions/ConditionRegisterNANDInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/ConditionRegisterNANDInstruction.cs
@@ -2,12 +2,10 @@
 {
     public sealed class ConditionRegisterNANDInstruction : GekkoInstruction
     {
-        public override int Address  { get; }
         public override int ByteCode { get; }
 
-        public ConditionRegisterNANDInstruction(int address, int crD, int crA, int crB)
+        public ConditionRegisterNANDInstruction(int address, int crD, int crA, int crB) : base(address)
         {
-            this.Address = address;
             this.ByteCode = (19 << 26 | crD << 21 | crA << 16 | crB << 11 | 225 << 1);
         }
     }

--- a/GekkoAssembler.Common/GekkoInstructions/ConditionRegisterNORInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/ConditionRegisterNORInstruction.cs
@@ -2,12 +2,10 @@
 {
     public sealed class ConditionRegisterNORInstruction : GekkoInstruction
     {
-        public override int Address  { get; }
         public override int ByteCode { get; }
 
-        public ConditionRegisterNORInstruction(int address, int crD, int crA, int crB)
+        public ConditionRegisterNORInstruction(int address, int crD, int crA, int crB) : base(address)
         {
-            this.Address = address;
             this.ByteCode = (19 << 26 | crD << 21 | crA << 16 | crB << 11 | 33 << 1);
         }
     }

--- a/GekkoAssembler.Common/GekkoInstructions/ConditionRegisterORComplementInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/ConditionRegisterORComplementInstruction.cs
@@ -2,12 +2,10 @@
 {
     public sealed class ConditionRegisterORComplementInstruction : GekkoInstruction
     {
-        public override int Address  { get; }
         public override int ByteCode { get; }
 
-        public ConditionRegisterORComplementInstruction(int address, int crD, int crA, int crB)
+        public ConditionRegisterORComplementInstruction(int address, int crD, int crA, int crB) : base(address)
         {
-            this.Address = address;
             this.ByteCode = (19 << 26 | crD << 21 | crA << 16 | crB << 11 | 417 << 1);
         }
     }

--- a/GekkoAssembler.Common/GekkoInstructions/ConditionRegisterORInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/ConditionRegisterORInstruction.cs
@@ -2,12 +2,10 @@
 {
     public sealed class ConditionRegisterORInstruction : GekkoInstruction
     {
-        public override int Address  { get; }
         public override int ByteCode { get; }
 
-        public ConditionRegisterORInstruction(int address, int crD, int crA, int crB)
+        public ConditionRegisterORInstruction(int address, int crD, int crA, int crB) : base(address)
         {
-            this.Address = address;
             this.ByteCode = (19 << 26 | crD << 21 | crA << 16 | crB << 11 | 449 << 1);
         }
     }

--- a/GekkoAssembler.Common/GekkoInstructions/ConditionRegisterXORInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/ConditionRegisterXORInstruction.cs
@@ -2,7 +2,6 @@
 {
     public class ConditionRegisterXORInstruction : GekkoInstruction
     {
-        public override int Address { get; }
         public override int ByteCode
             => (((((((((19 << 5) | ConditionRegisterDestination) << 5) | ConditionRegisterA) << 5) | ConditionRegisterB) << 10) | 193) << 1);
 
@@ -10,9 +9,8 @@
         public int ConditionRegisterA { get; }
         public int ConditionRegisterB { get; }
 
-        public ConditionRegisterXORInstruction(int address, int conditionRegisterDestination, int conditionRegisterA, int conditionRegisterB)
+        public ConditionRegisterXORInstruction(int address, int conditionRegisterDestination, int conditionRegisterA, int conditionRegisterB) : base(address)
         {
-            Address = address;
             ConditionRegisterDestination = conditionRegisterDestination;
             ConditionRegisterA = conditionRegisterA;
             ConditionRegisterB = conditionRegisterB;

--- a/GekkoAssembler.Common/GekkoInstructions/DivideWordInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/DivideWordInstruction.cs
@@ -2,7 +2,6 @@
 {
     public class DivideWordInstruction : GekkoInstruction
     {
-        public override int Address { get; }
         public override int ByteCode
             => 0x7C0003D6 | (RegisterDestination << 21) | (RegisterA << 16) | (RegisterB << 11) | ((OE ? 1 : 0) << 10) | (RC ? 1 : 0);
 
@@ -12,9 +11,8 @@
         public bool OE { get; }
         public bool RC { get; }
 
-        public DivideWordInstruction(int address, int registerDestination, int registerA, int registerB, bool oe = false, bool rc = false)
+        public DivideWordInstruction(int address, int registerDestination, int registerA, int registerB, bool oe = false, bool rc = false) : base(address)
         {
-            Address = address;
             RegisterDestination = registerDestination;
             RegisterA = registerA;
             RegisterB = registerB;

--- a/GekkoAssembler.Common/GekkoInstructions/GekkoInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/GekkoInstruction.cs
@@ -7,6 +7,12 @@ namespace GekkoAssembler.GekkoInstructions
     {
         public abstract int ByteCode { get; }
 
+        public override int Address { get; }
         public override byte[] Data => BitConverter.GetBytes(ByteCode).SwapEndian32();
+
+        protected GekkoInstruction(int address)
+        {
+            Address = address;
+        }
     }
 }

--- a/GekkoAssembler.Common/GekkoInstructions/InstructionCacheBlockInvalidateInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/InstructionCacheBlockInvalidateInstruction.cs
@@ -2,12 +2,10 @@
 {
     public sealed class InstructionCacheBlockInvalidateInstruction : GekkoInstruction
     {
-        public override int Address  { get; }
         public override int ByteCode { get; }
 
-        public InstructionCacheBlockInvalidateInstruction(int address, int rA, int rB)
+        public InstructionCacheBlockInvalidateInstruction(int address, int rA, int rB) : base(address)
         {
-            this.Address = address;
             this.ByteCode = (31 << 26 | rA << 16 | rB << 11 | 982 << 1);
         }
     }

--- a/GekkoAssembler.Common/GekkoInstructions/InstructionSynchronizeInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/InstructionSynchronizeInstruction.cs
@@ -2,12 +2,10 @@
 {
     public sealed class InstructionSynchronizeInstruction : GekkoInstruction
     {
-        public override int Address  { get; }
         public override int ByteCode { get; }
 
-        public InstructionSynchronizeInstruction(int address)
+        public InstructionSynchronizeInstruction(int address) : base(address)
         {
-            this.Address  = address;
             this.ByteCode = (19 << 26 | 150 << 1);
         }
     }

--- a/GekkoAssembler.Common/GekkoInstructions/LoadByteAndZeroInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/LoadByteAndZeroInstruction.cs
@@ -2,7 +2,6 @@
 {
     public class LoadByteAndZeroInstruction : GekkoInstruction
     {
-        public override int Address { get; }
         public override int ByteCode
             => (((((34 << 5) | RegisterDestination) << 5) | RegisterA) << 16) | Offset;
 
@@ -10,9 +9,8 @@
         public int RegisterA { get; }
         public int Offset { get; }
 
-        public LoadByteAndZeroInstruction(int address, int registerDestination, int registerA, int offset)
+        public LoadByteAndZeroInstruction(int address, int registerDestination, int registerA, int offset) : base(address)
         {
-            Address = address;
             RegisterDestination = registerDestination;
             RegisterA = registerA;
             Offset = offset;

--- a/GekkoAssembler.Common/GekkoInstructions/LoadFloatingPointSingleInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/LoadFloatingPointSingleInstruction.cs
@@ -2,7 +2,6 @@
 {
     public class LoadFloatingPointSingleInstruction : GekkoInstruction
     {
-        public override int Address { get; }
         public override int ByteCode
             => (((((48 << 5) | RegisterDestination) << 5) | RegisterA) << 16) | Offset;
 
@@ -10,9 +9,8 @@
         public int RegisterA { get; }
         public int Offset { get; }
 
-        public LoadFloatingPointSingleInstruction(int address, int registerDestination, int registerA, int offset)
+        public LoadFloatingPointSingleInstruction(int address, int registerDestination, int registerA, int offset) : base(address)
         {
-            Address = address;
             RegisterDestination = registerDestination;
             RegisterA = registerA;
             Offset = offset;

--- a/GekkoAssembler.Common/GekkoInstructions/LoadHalfWordAndZeroInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/LoadHalfWordAndZeroInstruction.cs
@@ -2,7 +2,6 @@
 {
     public class LoadHalfWordAndZeroInstruction : GekkoInstruction
     {
-        public override int Address { get; }
         public override int ByteCode
             => (((((40 << 5) | RegisterDestination) << 5) | RegisterA) << 16) | Offset;
 
@@ -10,9 +9,8 @@
         public int RegisterA { get; }
         public int Offset { get; }
 
-        public LoadHalfWordAndZeroInstruction(int address, int registerDestination, int registerA, int offset)
+        public LoadHalfWordAndZeroInstruction(int address, int registerDestination, int registerA, int offset) : base(address)
         {
-            Address = address;
             RegisterDestination = registerDestination;
             RegisterA = registerA;
             Offset = offset;

--- a/GekkoAssembler.Common/GekkoInstructions/LoadWordAndZeroInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/LoadWordAndZeroInstruction.cs
@@ -2,7 +2,6 @@
 {
     public class LoadWordAndZeroInstruction : GekkoInstruction
     {
-        public override int Address { get; }
         public override int ByteCode
             => (((((32 << 5) | RegisterDestination) << 5) | RegisterA) << 16) | Offset;
 
@@ -10,9 +9,8 @@
         public int RegisterA { get; }
         public int Offset { get; }
 
-        public LoadWordAndZeroInstruction(int address, int registerDestination, int registerA, int offset)
+        public LoadWordAndZeroInstruction(int address, int registerDestination, int registerA, int offset) : base(address)
         {
-            Address = address;
             RegisterDestination = registerDestination;
             RegisterA = registerA;
             Offset = offset;

--- a/GekkoAssembler.Common/GekkoInstructions/MoveFromSpecialPurposeRegisterInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/MoveFromSpecialPurposeRegisterInstruction.cs
@@ -2,16 +2,14 @@
 {
     public class MoveFromSpecialPurposeRegisterInstruction : GekkoInstruction
     {
-        public override int Address { get; }
         public override int ByteCode
             => 0x7C0002A6 | (RegisterDestination << 21) | ((SpecialPurposeRegisterID & 0x1F) << 16) | ((SpecialPurposeRegisterID >> 5) << 11);
 
         public int RegisterDestination { get; }
         public int SpecialPurposeRegisterID { get; }
 
-        public MoveFromSpecialPurposeRegisterInstruction(int address, int registerDestination, int specialPurposeRegister)
+        public MoveFromSpecialPurposeRegisterInstruction(int address, int registerDestination, int specialPurposeRegister) : base(address)
         {
-            Address = address;
             RegisterDestination = registerDestination;
             SpecialPurposeRegisterID = specialPurposeRegister;
         }

--- a/GekkoAssembler.Common/GekkoInstructions/MoveToSpecialPurposeRegisterInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/MoveToSpecialPurposeRegisterInstruction.cs
@@ -2,16 +2,14 @@
 {
     public class MoveToSpecialPurposeRegisterInstruction : GekkoInstruction
     {
-        public override int Address { get; }
         public override int ByteCode
             => 0x7C0003A6 | (RegisterSource << 21) | ((SpecialPurposeRegisterID & 0x1F) << 16) | ((SpecialPurposeRegisterID >> 5) << 11);
 
         public int SpecialPurposeRegisterID { get; }
         public int RegisterSource { get; }
 
-        public MoveToSpecialPurposeRegisterInstruction(int address, int specialPurposeRegister, int registerSource)
+        public MoveToSpecialPurposeRegisterInstruction(int address, int specialPurposeRegister, int registerSource) : base(address)
         {
-            Address = address;
             RegisterSource = registerSource;
             SpecialPurposeRegisterID = specialPurposeRegister;
         }

--- a/GekkoAssembler.Common/GekkoInstructions/MultiplyLowImmediateInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/MultiplyLowImmediateInstruction.cs
@@ -2,7 +2,6 @@
 {
     public class MultiplyLowImmediateInstruction : GekkoInstruction
     {
-        public override int Address { get; }
         public override int ByteCode
             => (((((7 << 5) | RegisterDestination) << 5) | RegisterA) << 16) | (SIMM & 0xFFFF);
 
@@ -10,9 +9,8 @@
         public int RegisterA { get; }
         public int SIMM { get; }
 
-        public MultiplyLowImmediateInstruction(int address, int registerDestination, int registerA, int simm)
+        public MultiplyLowImmediateInstruction(int address, int registerDestination, int registerA, int simm) : base(address)
         {
-            Address = address;
             RegisterDestination = registerDestination;
             RegisterA = registerA;
             SIMM = simm;

--- a/GekkoAssembler.Common/GekkoInstructions/MultiplyLowWordInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/MultiplyLowWordInstruction.cs
@@ -2,7 +2,6 @@
 {
     public class MultiplyLowWordInstruction : GekkoInstruction
     {
-        public override int Address { get; }
         public override int ByteCode
             => 0x7C0001D6 | (RegisterDestination << 21) | (RegisterA << 16) | (RegisterB << 11) | ((OE ? 1 : 0) << 10) | (RC ? 1 : 0);
 
@@ -12,9 +11,8 @@
         public bool OE { get; }
         public bool RC { get; }
 
-        public MultiplyLowWordInstruction(int address, int registerDestination, int registerA, int registerB, bool oe = false, bool rc = false)
+        public MultiplyLowWordInstruction(int address, int registerDestination, int registerA, int registerB, bool oe = false, bool rc = false) : base(address)
         {
-            Address = address;
             RegisterDestination = registerDestination;
             RegisterA = registerA;
             RegisterB = registerB;

--- a/GekkoAssembler.Common/GekkoInstructions/OrImmediateInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/OrImmediateInstruction.cs
@@ -2,7 +2,6 @@
 {
     public class OrImmediateInstruction : GekkoInstruction
     {
-        public override int Address { get; }
         public override int ByteCode
             => (((((24 << 5) | RegisterSource) << 5) | RegisterA) << 16) | UIMM;
 
@@ -10,9 +9,8 @@
         public int RegisterSource { get; }
         public int UIMM { get; }
 
-        public OrImmediateInstruction(int address, int registerA, int registerSource, int uimm)
+        public OrImmediateInstruction(int address, int registerA, int registerSource, int uimm) : base(address)
         {
-            Address = address;
             RegisterA = registerA;
             RegisterSource = registerSource;
             UIMM = uimm;

--- a/GekkoAssembler.Common/GekkoInstructions/StoreWordInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/StoreWordInstruction.cs
@@ -2,7 +2,6 @@
 {
     public class StoreWordInstruction : GekkoInstruction
     {
-        public override int Address { get; }
         public override int ByteCode
             => (((((36 << 5) | RegisterSource) << 5) | (RegisterAddress & 0x1F)) << 16) | (Offset & 0xFFFF);
 
@@ -10,9 +9,8 @@
         public int RegisterAddress { get; }
         public int Offset { get; }
 
-        public StoreWordInstruction(int address, int registerSource, int offset, int registerAddress)
+        public StoreWordInstruction(int address, int registerSource, int offset, int registerAddress) : base(address)
         {
-            Address = address;
             RegisterSource = registerSource;
             RegisterAddress = registerAddress;
             Offset = offset;

--- a/GekkoAssembler.Common/GekkoInstructions/StoreWordWithUpdateInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/StoreWordWithUpdateInstruction.cs
@@ -2,7 +2,6 @@
 {
     public class StoreWordWithUpdateInstruction : GekkoInstruction
     {
-        public override int Address { get; }
         public override int ByteCode
             => (((((37 << 5) | RegisterSource) << 5) | (RegisterAddress & 0x1F)) << 16) | (Offset & 0xFFFF);
 
@@ -10,9 +9,8 @@
         public int RegisterAddress { get; }
         public int Offset { get; }
 
-        public StoreWordWithUpdateInstruction(int address, int registerSource, int offset, int registerAddress)
+        public StoreWordWithUpdateInstruction(int address, int registerSource, int offset, int registerAddress) : base(address)
         {
-            Address = address;
             RegisterSource = registerSource;
             RegisterAddress = registerAddress;
             Offset = offset;

--- a/GekkoAssembler.Common/GekkoInstructions/SubtractFromInstruction.cs
+++ b/GekkoAssembler.Common/GekkoInstructions/SubtractFromInstruction.cs
@@ -2,7 +2,6 @@
 {
     public class SubtractFromInstruction : GekkoInstruction
     {
-        public override int Address { get; }
         public override int ByteCode
             => 0x7C000050 | (RegisterDestination << 21) | (RegisterA << 16) | (RegisterB << 11) | ((OE ? 1 : 0) << 10) | (RC ? 1 : 0);
 
@@ -12,9 +11,8 @@
         public bool OE { get; }
         public bool RC { get; }
 
-        public SubtractFromInstruction(int address, int registerDestination, int registerA, int registerB, bool oe = false, bool rc = false)
+        public SubtractFromInstruction(int address, int registerDestination, int registerA, int registerB, bool oe = false, bool rc = false) : base(address)
         {
-            Address = address;
             RegisterDestination = registerDestination;
             RegisterA = registerA;
             RegisterB = registerB;


### PR DESCRIPTION
Gets rid of needing to redeclare the same getter in every instruction class.
